### PR TITLE
 nes-embed.jsの内容を共通化

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,15 @@
             }
         }
         window.onload = function() {
+            window.addEventListener('keydown', function(event) {
+                switch (event.keyCode) {
+                    case 37: // ←
+                    case 38: // ↑
+                    case 39: // →
+                    case 40: // ↓
+                        event.preventDefault();
+                }
+            }, true);
             if (window.RPGAtsumaru) {
                 window.RPGAtsumaru.storage.getItems().then(function(keys) {
                     if (keys) {

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-    <title>BATTLE MARINE - WEB PLAY</title>
+    <title>JSNES ON RPG ATSUMARU</title>
 
     <script type="text/javascript" src="jsnes.min.js"></script>
     <script type="text/javascript" src="wram-check.js"></script>

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
     <title>BATTLE MARINE - WEB PLAY</title>
 
     <script type="text/javascript" src="jsnes.min.js"></script>
+    <script type="text/javascript" src="wram-check.js"></script>
     <script type="text/javascript" src="nes-embed.js"></script>
     <script type="text/javascript" src="AtsumaruScoreboardsExperimental.js"></script>
     <script>

--- a/nes-embed.js
+++ b/nes-embed.js
@@ -319,10 +319,10 @@ function onAnimationFrame() {
     canvas_main.restore();
     nes.frame();
     if (window.onGameOver) {
-        if (!window.detectGameOver && 0 != nes.cpu.mem[0x02] && 0 < nes.cpu.mem[0x6c] && nes.cpu.mem[0x6c] < 0x30) {
+        if (!window.detectGameOver && wram_check_onStartGameOver()) {
             window.detectGameOver = true;
-            window.onGameOver(10 * (parseInt(nes.cpu.mem[0x66]) + parseInt(nes.cpu.mem[0x67]) * 256 + parseInt(nes.cpu.mem[0x68]) * 65536));
-        } else if (0 == nes.cpu.mem[0x02]) {
+            window.onGameOver(wram_check_getScore());
+        } else if (wram_check_onEndGameOver()) {
             window.detectGameOver = false;
         }
     }

--- a/nes-embed.js
+++ b/nes-embed.js
@@ -418,13 +418,23 @@ function nes_load_url(canvas_id, path) {
     var canvas = document.getElementById('main-canvas');
     canvas_main = canvas.getContext("2d");
     canvas.addEventListener('touchend', function(event) {
-        if (window.RPGAtsumaru) {
-            window.RPGAtsumaru.experimental.scoreboards.display(1);
+        var z = 640 / canvas.clientWidth;
+        var x = event.offsetX * z;
+        if (512 <= x && x < 640) {
+            console.log("open leaderboard");
+            if (window.RPGAtsumaru) {
+                window.RPGAtsumaru.experimental.scoreboards.display(1);
+            }
         }
     }, false);
     canvas.addEventListener('click', function(event) {
-        if (window.RPGAtsumaru) {
-            window.RPGAtsumaru.experimental.scoreboards.display(1);
+        var z = 640 / canvas.clientWidth;
+        var x = event.offsetX * z;
+        if (512 <= x && x < 640) {
+            console.log("open leaderboard");
+            if (window.RPGAtsumaru) {
+                window.RPGAtsumaru.experimental.scoreboards.display(1);
+            }
         }
     }, false);
     var req = new XMLHttpRequest();

--- a/wram-check.js
+++ b/wram-check.js
@@ -1,0 +1,11 @@
+function wram_check_onStartGameOver() {
+    return 0 != nes.cpu.mem[0x02] && 0 < nes.cpu.mem[0x6c] && nes.cpu.mem[0x6c] < 0x30;
+}
+
+function wram_check_getScore() {
+    return 10 * (parseInt(nes.cpu.mem[0x66]) + parseInt(nes.cpu.mem[0x67]) * 256 + parseInt(nes.cpu.mem[0x68]) * 65536);
+}
+
+function wram_check_onEndGameOver() {
+    return 0 == nes.cpu.mem[0x02];
+}


### PR DESCRIPTION
修正する際にコピペではなる丸っとコピーできるようにするため、専用処理をwram-check.jsに分離